### PR TITLE
Fix transmission redirect

### DIFF
--- a/files/downloader.conf
+++ b/files/downloader.conf
@@ -15,7 +15,7 @@ server {
   }
 
   location /torrent/ {
-    rewrite /torrent/(.*) /transmission/$1 break;
+    return 301 /transmission/web/;
   }
 
   location /transmission/ {


### PR DESCRIPTION
For /torrent/ to redirect to /transmission/web/, I need to use a 301
instead of rewrite. This fixes the issue where /torrent/ returns a 404.